### PR TITLE
Rework of BufferedWriter to be safer and more flexible

### DIFF
--- a/buffered_writer.go
+++ b/buffered_writer.go
@@ -10,29 +10,49 @@ import (
 type BufferedWriter struct {
 	buf    *bufio.Writer
 	writer io.WriteCloser
+	mc chan string
+	fc chan int
 }
 
 func NewBufferedWriter(writer io.WriteCloser) *BufferedWriter {
 	bw := new(BufferedWriter)
 	bw.writer = writer
 	bw.buf = bufio.NewWriter(writer)
+	bw.mc = make(chan string)
+	bw.fc = make(chan int)
+	go bw.writeLoop()
 	return bw
 }
 
-func (bw *BufferedWriter) LogWrite(msg string) {
-	_, err := bw.buf.Write([]byte(msg))
-	if err != nil {
-		// uh-oh... what do i do if logging fails; punt!
-		log.Printf("TIMBER! epic fail: %v", err)
+func (bw *BufferedWriter) writeLoop() {
+	for {
+		select {
+		case msg, ok := <- bw.mc:
+			if !ok {
+				bw.buf.Flush()
+				bw.writer.Close()
+				return
+			}
+			_, err := bw.buf.Write([]byte(msg))
+			if err != nil {
+				// uh-oh... what do i do if logging fails; punt!
+				log.Printf("TIMBER! epic fail: %v", err)
+			}
+		case <- bw.fc:
+			bw.buf.Flush()
+		}
 	}
+}
+
+func (bw *BufferedWriter) LogWrite(msg string) {
+	bw.mc <- msg
 }
 
 // Force flush the buffer
 func (bw *BufferedWriter) Flush() {
-	bw.buf.Flush()
+	bw.fc <- 1
 }
 
 func (bw *BufferedWriter) Close() {
-	bw.buf.Flush()
-	bw.writer.Close()
+	close(bw.mc)
 }

--- a/buffered_writer.go
+++ b/buffered_writer.go
@@ -27,6 +27,11 @@ func (bw *BufferedWriter) LogWrite(msg string) {
 	}
 }
 
+// Force flush the buffer
+func (bw *BufferedWriter) Flush() {
+	bw.buf.Flush()
+}
+
 func (bw *BufferedWriter) Close() {
 	bw.buf.Flush()
 	bw.writer.Close()


### PR DESCRIPTION
Two issues I'm solving here:
1) bufio.Writer isn't safe to be accessed from multiple goroutines at once.
2) buffer flushing is based on buffer size.  apps that log take forever to flush

Solutions:
1) changed all operations on bufio.Writer to happen in a goroutine
2) added an explicit Flush method
