### PR TITLE
syslog sucks

### DIFF
--- a/syslog_formatter.go
+++ b/syslog_formatter.go
@@ -45,7 +45,7 @@ func NewSyslogFormatter(format string) *SyslogFormatter {
 
 func (sf *SyslogFormatter) Format(rec *LogRecord) string {
 	msg := sf.pf.Format(rec)
-	return fmt.Sprintf("<%d>%s %s[%d]: %s",
+	return fmt.Sprintf("<%d>%.15s %s[%d]: %s",
 		sf.Facility|sf.SeverityMap[rec.Level],
 		rec.Timestamp.Format(time.Stamp),
 		sf.Tag,

--- a/syslog_formatter.go
+++ b/syslog_formatter.go
@@ -45,10 +45,9 @@ func NewSyslogFormatter(format string) *SyslogFormatter {
 
 func (sf *SyslogFormatter) Format(rec *LogRecord) string {
 	msg := sf.pf.Format(rec)
-	return fmt.Sprintf("<%d>%s %s %s[%d]: %s",
+	return fmt.Sprintf("<%d>%s %s[%d]: %s",
 		sf.Facility|sf.SeverityMap[rec.Level],
-		rec.Timestamp.Format(time.RFC3339),
-		sf.Hostname,
+		rec.Timestamp.Format(time.Stamp),
 		sf.Tag,
 		sf.pid,
 		msg)


### PR DESCRIPTION
The go1.1 format implementation that I copied prints all sorts of garbage in rsyslogd (ubuntu) because of the timestamp format.  Same for mac os x.  This new format works and I figured it out from snooping the output of the logger command on ubuntu but is totally fucking broken on mac os. At this point I'm done fucking with it unless someone asks for mac os syslog to work.  

It kinda matches the old RFC 3164 but the hostname field didn't work right (rsyslog would just put the hostname doubled).
