### PR TITLE
don't try and build syslog formatter on platforms which lack log/syslog

### DIFF
--- a/pattern_formatter.go
+++ b/pattern_formatter.go
@@ -119,6 +119,14 @@ func (pf *PatFormatter) compileForLevel(level int) []byte {
 			sprintfFmt = append(sprintfFmt, 's')
 			sprintfFmt = append(sprintfFmt, fmt_str[1:]...)
 			pf.formatDynamic = append(pf.formatDynamic, 'L')
+                case 'l':
+                        sprintfFmt = append(sprintfFmt, '%')
+                        if num != nil {
+                                sprintfFmt = append(sprintfFmt, num...)
+                        }
+                        sprintfFmt = append(sprintfFmt, 's')
+                        sprintfFmt = append(sprintfFmt, fmt_str[1:]...)
+                        pf.formatDynamic = append(pf.formatDynamic, 'l')
 		case 'S':
 			sprintfFmt = append(sprintfFmt, '%')
 			if num != nil {
@@ -202,6 +210,8 @@ func (pf *PatFormatter) getDynamic(rec *LogRecord) []interface{} {
 			ret = append(ret, parseDate(tm)...)
 		case 'L':
 			ret = append(ret, LevelStrings[rec.Level])
+                case 'l':
+                        ret = append(ret, LongLevelStrings[rec.Level])
 		case 'S':
 			ret = append(ret, parseSourceLong(rec.SourceFile, rec.SourceLine))
 		case 's':

--- a/pattern_formatter_test.go
+++ b/pattern_formatter_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 var lr = &LogRecord{
-	Level:       INFO,
-	Timestamp:   time.Unix(0, 1319150347383485000),
+	Level:       WARNING,
+	Timestamp:   time.Unix(0, 1319230347383485000),
 	SourceFile:  "/blah/der/some_file.go",
 	SourceLine:  7,
 	Message:     "hellooooo nurse!",
@@ -20,11 +20,11 @@ var optiontests = []struct {
 	in  string
 	out string
 }{
-	{"%T", "15:39:07.383\n"},
-	{"%t", "15:39:07\n"},
-	{"%D", "2011-10-20\n"},
-	{"%d", "2011/10/20\n"},
-	{"%-10L", "INFO      \n"},
+	{"%T", "21:52:27.383\n"},
+	{"%t", "21:52:27\n"},
+	{"%D", "2011-10-21\n"},
+	{"%d", "2011/10/21\n"},
+	{"%-10L", "WARN      \n"},
 	{"%S", "/blah/der/some_file.go:7\n"},
 	{"%s", "some_file.go:7\n"},
 	{"%x", "some_file\n"},
@@ -49,7 +49,7 @@ func TestOptions(t *testing.T) {
 
 func TestWorstPatternFormat(t *testing.T) {
 	in := "short:[%d %t] good:[%D %T] levelPadded:[%-10L] long:%S short:%s xs:%10x Msg:%M Fnc:%P Pkg:%p"
-	out := "short:[2011/10/20 15:39:07] good:[2011-10-20 15:39:07.383] levelPadded:[INFO      ] " +
+	out := "short:[2011/10/21 21:52:27] good:[2011-10-21 21:52:27.383] levelPadded:[WARN      ] " +
 		"long:/blah/der/some_file.go:7 short:some_file.go:7 xs: some_file Msg:hellooooo nurse! Fnc:hi.Zoot Pkg:hi\n"
 	pf := NewPatFormatter(in)
 	verify(t, in, pf.Format(lr), out)
@@ -57,9 +57,16 @@ func TestWorstPatternFormat(t *testing.T) {
 
 func TestRealPatternFormat(t *testing.T) {
 	in := "[%D %T] [%L] %-10x %M"
-	out := "[2011-10-20 15:39:07.383] [INFO] some_file  hellooooo nurse!\n"
+	out := "[2011-10-21 21:52:27.383] [WARN] some_file  hellooooo nurse!\n"
 	pf := NewPatFormatter(in)
 	verify(t, in, pf.Format(lr), out)
+}
+
+func TestRealPatternFormatLong(t *testing.T) {
+        in := "[%D %T] [%l] %-10x %M"
+        out := "[2011-10-21 21:52:27.383] [WARNING] some_file  hellooooo nurse!\n"
+        pf := NewPatFormatter(in)
+        verify(t, in, pf.Format(lr), out)
 }
 
 func BenchmarkWorstPatternFormat(b *testing.B) {
@@ -72,8 +79,8 @@ func BenchmarkWorstPatternFormat(b *testing.B) {
 func BenchmarkWorstJustSprintf(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		fmt.Sprintf("short:[%d/%02d/%02d %02d:%02d:%02d] good:[%d-%02d-%02d %02d:%02d:%02d.%03d] "+
-			"levelPadded:[%-10s] long:%s short:%s xs:%10s Msg:%s Fnc:%s Pkg:%s\n", 2011, 10, 20, 15, 39, 7,
-			2011, 10, 20, 15, 39, 7, 383, "INFO", "/blah/der/some_file.go:7", "some_file.go:7", "some_file", "hellooooo nurse!", "hi.Zoot", "hi")
+			"levelPadded:[%-10s] long:%s short:%s xs:%10s Msg:%s Fnc:%s Pkg:%s\n", 2011, 10, 21, 23, 39, 7,
+			2011, 10, 21, 23, 39, 7, 383, "WARN", "/blah/der/some_file.go:7", "some_file.go:7", "some_file", "hellooooo nurse!", "hi.Zoot", "hi")
 	}
 }
 
@@ -86,6 +93,6 @@ func BenchmarkRealPatternFormat(b *testing.B) {
 
 func BenchmarkReallJustSprintf(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		fmt.Sprintf("[%d-%02d-%02d %02d:%02d:%02d.%03d] [%s] %-10s %s\n", 2011, 10, 20, 15, 39, 7, 383, "INFO", "some_file", "hellooooo nurse!")
+		fmt.Sprintf("[%d-%02d-%02d %02d:%02d:%02d.%03d] [%s] %-10s %s\n", 2011, 10, 21, 23, 39, 7, 383, "WARN", "some_file", "hellooooo nurse!")
 	}
 }

--- a/syslog_formatter.go
+++ b/syslog_formatter.go
@@ -1,3 +1,5 @@
+// Same build constraints as log/syslog
+// +build !windows,!plan9
 package timber
 
 import (

--- a/syslog_formatter.go
+++ b/syslog_formatter.go
@@ -1,5 +1,6 @@
 // Same build constraints as log/syslog
 // +build !windows,!plan9
+
 package timber
 
 import (

--- a/timber.go
+++ b/timber.go
@@ -593,15 +593,26 @@ func Warn(arg0 interface{}, args ...interface{}) error     { return Global.Warn(
 func Error(arg0 interface{}, args ...interface{}) error    { return Global.Error(arg0, args...) }
 func Critical(arg0 interface{}, args ...interface{}) error { return Global.Critical(arg0, args...) }
 func Log(lvl Level, arg0 interface{}, args ...interface{}) { Global.Log(lvl, arg0, args...) }
-func Print(v ...interface{})                               { Global.Print(v...) }
-func Printf(format string, v ...interface{})               { Global.Printf(format, v...) }
-func Println(v ...interface{})                             { Global.Println(v...) }
-func Panic(v ...interface{})                               { Global.Panic(v...) }
-func Panicf(format string, v ...interface{})               { Global.Panicf(format, v...) }
-func Panicln(v ...interface{})                             { Global.Panicln(v...) }
-func Fatal(v ...interface{})                               { Global.Fatal(v...) }
-func Fatalf(format string, v ...interface{})               { Global.Fatalf(format, v...) }
-func Fatalln(v ...interface{})                             { Global.Fatalln(v...) }
+
+func Finestf(arg0 interface{}, args ...interface{})         { Global.Finestf(arg0, args...) }
+func Finef(arg0 interface{}, args ...interface{})           { Global.Finef(arg0, args...) }
+func Debugf(arg0 interface{}, args ...interface{})          { Global.Debugf(arg0, args...) }
+func Tracef(arg0 interface{}, args ...interface{})          { Global.Tracef(arg0, args...) }
+func Infof(arg0 interface{}, args ...interface{})           { Global.Infof(arg0, args...) }
+func Warnf(arg0 interface{}, args ...interface{}) error     { return Global.Warnf(arg0, args...) }
+func Errorf(arg0 interface{}, args ...interface{}) error    { return Global.Errorf(arg0, args...) }
+func Criticalf(arg0 interface{}, args ...interface{}) error { return Global.Criticalf(arg0, args...) }
+func Logf(lvl Level, arg0 interface{}, args ...interface{}) { Global.Logf(lvl, arg0, args...) }
+
+func Print(v ...interface{})                 { Global.Print(v...) }
+func Printf(format string, v ...interface{}) { Global.Printf(format, v...) }
+func Println(v ...interface{})               { Global.Println(v...) }
+func Panic(v ...interface{})                 { Global.Panic(v...) }
+func Panicf(format string, v ...interface{}) { Global.Panicf(format, v...) }
+func Panicln(v ...interface{})               { Global.Panicln(v...) }
+func Fatal(v ...interface{})                 { Global.Fatal(v...) }
+func Fatalf(format string, v ...interface{}) { Global.Fatalf(format, v...) }
+func Fatalln(v ...interface{})               { Global.Fatalln(v...) }
 
 func AddLogger(logger ConfigLogger) int { return Global.AddLogger(logger) }
 func Close()                            { Global.Close() }

--- a/timber.go
+++ b/timber.go
@@ -136,9 +136,7 @@ const (
 const DefaultFileDepth int = 3
 
 // What gets printed for each Log level
-// var LevelStrings = [...]string{"", "FNST", "FINE", "DEBG", "TRAC", "INFO", "WARN", "EROR", "CRIT"}
-// Some sysadmins like to grep -i err
-var LevelStrings = [...]string{"", "FNEST", "FINE ", "DEBUG", "TRACE", "INFO ", "WARN ", "ERROR", "CRIT "}
+var LevelStrings = [...]string{"", "FNST", "FINE", "DEBG", "TRAC", "INFO", "WARN", "EROR", "CRIT"}
 
 // Full level names
 var LongLevelStrings = []string{

--- a/timber.go
+++ b/timber.go
@@ -186,6 +186,17 @@ type Logger interface {
 	Fatal(v ...interface{})
 	Fatalf(format string, v ...interface{})
 	Fatalln(v ...interface{})
+
+	// and govet-friendly versions of log4go
+	Finestf(arg0 interface{}, args ...interface{})
+	Finef(arg0 interface{}, args ...interface{})
+	Debugf(arg0 interface{}, args ...interface{})
+	Tracef(arg0 interface{}, args ...interface{})
+	Infof(arg0 interface{}, args ...interface{})
+	Warnf(arg0 interface{}, args ...interface{}) error
+	Errorf(arg0 interface{}, args ...interface{}) error
+	Criticalf(arg0 interface{}, args ...interface{}) error
+	Logf(lvl Level, arg0 interface{}, args ...interface{})
 }
 
 // Not used
@@ -377,7 +388,6 @@ func (t *Timber) AddLogger(logger ConfigLogger) int {
 	return <-tcChan
 }
 
-
 func (t *Timber) SetLogger(index int, logger ConfigLogger) {
 	tcChan := make(chan int, 1) // buffered
 	tc := timberConfig{Action: actionSet, Cfg: logger, Ret: tcChan}
@@ -477,6 +487,42 @@ func (t *Timber) Critical(arg0 interface{}, args ...interface{}) error {
 	return errors.New(msg)
 }
 func (t *Timber) Log(lvl Level, arg0 interface{}, args ...interface{}) {
+	t.prepareAndSend(lvl, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+}
+
+// The govet printf family of warnings triggers on Erorr() and similar containing format strings
+// Add more golike Foof() formatters. Other methods should be considered deprecated
+func (t *Timber) Finestf(arg0 interface{}, args ...interface{}) {
+	t.prepareAndSend(FINEST, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+}
+func (t *Timber) Finef(arg0 interface{}, args ...interface{}) {
+	t.prepareAndSend(FINE, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+}
+func (t *Timber) Debugf(arg0 interface{}, args ...interface{}) {
+	t.prepareAndSend(DEBUG, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+}
+func (t *Timber) Tracef(arg0 interface{}, args ...interface{}) {
+	t.prepareAndSend(TRACE, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+}
+func (t *Timber) Infof(arg0 interface{}, args ...interface{}) {
+	t.prepareAndSend(INFO, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
+}
+func (t *Timber) Warnf(arg0 interface{}, args ...interface{}) error {
+	msg := fmt.Sprintf(arg0.(string), args...)
+	t.prepareAndSend(WARNING, msg, t.FileDepth)
+	return errors.New(msg)
+}
+func (t *Timber) Errorf(arg0 interface{}, args ...interface{}) error {
+	msg := fmt.Sprintf(arg0.(string), args...)
+	t.prepareAndSend(ERROR, msg, t.FileDepth)
+	return errors.New(msg)
+}
+func (t *Timber) Criticalf(arg0 interface{}, args ...interface{}) error {
+	msg := fmt.Sprintf(arg0.(string), args...)
+	t.prepareAndSend(CRITICAL, msg, t.FileDepth)
+	return errors.New(msg)
+}
+func (t *Timber) Logf(lvl Level, arg0 interface{}, args ...interface{}) {
 	t.prepareAndSend(lvl, fmt.Sprintf(arg0.(string), args...), t.FileDepth)
 }
 

--- a/timber.go
+++ b/timber.go
@@ -136,7 +136,9 @@ const (
 const DefaultFileDepth int = 3
 
 // What gets printed for each Log level
-var LevelStrings = [...]string{"", "FNST", "FINE", "DEBG", "TRAC", "INFO", "WARN", "EROR", "CRIT"}
+// var LevelStrings = [...]string{"", "FNST", "FINE", "DEBG", "TRAC", "INFO", "WARN", "EROR", "CRIT"}
+// Some sysadmins like to grep -i err
+var LevelStrings = [...]string{"", "FNEST", "FINE ", "DEBUG", "TRACE", "INFO ", "WARN ", "ERROR", "CRIT "}
 
 // Full level names
 var LongLevelStrings = []string{


### PR DESCRIPTION
timber fails to build on windows, due to
log/syslog having a build restriction (!windows,!plan9): http://golang.org/src/pkg/log/syslog/syslog.go

This adds the same restriction to the syslog formatter, fixing the windows build
